### PR TITLE
Remove support for Python 2.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
 
 [global]
 setup-hooks =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pep8,pyflakes
+envlist = py27,pep8,pyflakes
 minversion = 1.4.0
 
 [tox:jenkins]


### PR DESCRIPTION
PyYAML doesnt support Python 2.6, and
the target market of this tool is unlikely
to need to use Python 2.6.